### PR TITLE
CMake: Use targets instead of variables for dependency management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,24 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.6)
 project(kmsgrab LANGUAGES C VERSION 0.1)
 
 include(GNUInstallDirs)
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(PNG QUIET libpng)
-if (NOT PNG_FOUND)
-	message(FATAL_ERROR "Missing dependency: libpng")
-endif()
+pkg_check_modules(PNG REQUIRED
+	IMPORTED_TARGET
+	libpng
+)
 
-pkg_check_modules(DRM QUIET libdrm)
-if (NOT DRM_FOUND)
-	message(FATAL_ERROR "Missing dependency: libdrm")
-endif()
+pkg_check_modules(DRM REQUIRED
+	IMPORTED_TARGET
+	libdrm
+)
 
 add_executable(kmsgrab kmsgrab.c)
 
-target_include_directories(kmsgrab PRIVATE
-	${PNG_INCLUDE_DIRS}
-	${DRM_INCLUDE_DIRS}
-)
-
-target_link_directories(kmsgrab PRIVATE
-	${PNG_LIBRARY_DIRS}
-	${DRM_LIBRARY_DIRS}
-)
-
 target_link_libraries(kmsgrab PRIVATE
-	${PNG_LIBRARIES}
-	${DRM_LIBRARIES}
+	PkgConfig::PNG
+	PkgConfig::DRM
 )
 
 install(TARGETS kmsgrab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,8 @@ cmake_minimum_required(VERSION 3.6)
 project(kmsgrab LANGUAGES C VERSION 0.1)
 
 include(GNUInstallDirs)
+find_package(PNG REQUIRED)
 find_package(PkgConfig REQUIRED)
-
-pkg_check_modules(PNG REQUIRED
-	IMPORTED_TARGET
-	libpng
-)
 
 pkg_check_modules(DRM REQUIRED
 	IMPORTED_TARGET
@@ -17,7 +13,7 @@ pkg_check_modules(DRM REQUIRED
 add_executable(kmsgrab kmsgrab.c)
 
 target_link_libraries(kmsgrab PRIVATE
-	PkgConfig::PNG
+	PNG::PNG
 	PkgConfig::DRM
 )
 


### PR DESCRIPTION
Concerning the references to the CMake documentation in the commit messages,
I've decided to let them point to the latest concrete version (which is 3.28 as
of this writing).
Although it is possible to point to the "latest" version [1], there is a risk
that links to specific pages and/or anchors will stop working, should the CMake
developers decide to restructure the documentation in the future.

By the way, thank you for this nice tool.
I've stumbled upon it while searching the OpenEmbedded Layer Index for an
alternative to `fbgrab`, but for KMS/DRM instead of framebuffer. [2]
It has helped me to debug a problem on an embedded system with a tiny
monochrome display of just 128x64 pixels.

[1] https://cmake.org/cmake/help/latest/
[2] https://layers.openembedded.org/layerindex/recipe/332830/